### PR TITLE
Release v0.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Run supply chain security scan
         run: |
-          cargo tree --format "{p} {l}" | grep -E "(GPL|AGPL)" && exit 1 || echo "No GPL/AGPL licenses found"
+          cargo tree --format "{p} {l}" | grep -E "(GPL|AGPL)" | grep -vE "\bOR\b.*(GPL|AGPL)|(GPL|AGPL).*\bOR\b" && exit 1 || echo "No GPL/AGPL-only licenses found"
 
   # Performance regression check
   performance-check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-06
+
+### 🔧 Enhanced
+
+#### Dependency Updates
+- **Nushell 0.111.0**: Updated nu-plugin, nu-protocol, and nu-test-support to 0.111.0
+
+#### New Commands & Operations
+- **`secret validate-format`**: Pattern-based format validation for secrets (email, UUID, hex, base64, JWT, custom regex)
+- **`secret is-empty`**: Empty content detection for secret values
+- **Ordering operators**: Added `<`, `>`, `<=`, `>=` support for SecretInt, SecretFloat, and SecretDate
+- **Extended format validators**: Added ipv4, ipv6, ssn, and credit-card format validators with Luhn checksum
+- **Equality operators**: Added equality operators (`==`, `!=`) for all secret types
+
+#### CI/CD Improvements
+- **Trivy action update**: Updated vulnerability scanner from 0.33.1 to 0.35.0
+- **Supply chain check fix**: Exclude dual-licensed crates (e.g., `Apache-2.0 OR GPL-2.0-only`) from GPL/AGPL check
+- **Nushell integration test**: Updated CI to install Nushell 0.111.0
+
+#### Code Quality
+- **Style guide**: Added comprehensive coding conventions documentation
+- **ADR framework**: Established Architecture Decision Records
+- **Module documentation**: Added module-level docs to command and type modules
+- **Import ordering**: Enforced consistent import ordering across all source files
+
 ## [0.6.0] - 2026-02-05
 
 ### 🔧 Enhanced
@@ -315,6 +340,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation**: Complete user and developer documentation
 - **Community**: Contributing guidelines and security vulnerability disclosure
 
+[0.7.0]: https://github.com/nushell-works/nu_plugin_secret/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/nushell-works/nu_plugin_secret/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/nushell-works/nu_plugin_secret/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/nushell-works/nu_plugin_secret/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/nushell-works/nu_plugin_secret/compare/v0.2.0...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_secret"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu_plugin_secret"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["John Ky <newhoggy@gmail.com>"]
 description = "Production-grade secret handling plugin for Nushell with secure CustomValue types that prevent accidental exposure of sensitive data"


### PR DESCRIPTION
## Summary
- Bump version from 0.6.0 to 0.7.0
- Update CHANGELOG with all changes since v0.6.0
- Fix release workflow GPL/AGPL check for dual-licensed crates

## Changes since v0.6.0
- **Nushell 0.111.0**: Upgraded nu-plugin, nu-protocol, nu-test-support
- **New commands**: `secret validate-format`, `secret is-empty`
- **Ordering operators**: `<`, `>`, `<=`, `>=` for SecretInt, SecretFloat, SecretDate
- **Extended validators**: ipv4, ipv6, ssn, credit-card formats
- **Equality operators**: `==`, `!=` for all secret types
- **CI fixes**: Trivy action update, supply chain check, Nushell integration test
- **Code quality**: Style guide, ADR framework, module docs, import ordering

## Test plan
- [ ] CI passes (clippy, tests, Miri, integration)
- [ ] After merge, tag `v0.7.0` to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)